### PR TITLE
Add admin merchant enable/disable buttons & group by status functionality

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,6 +1,7 @@
 class Admin::MerchantsController < ApplicationController
   def index
-    @merchants = Merchant.all
+    @enabled_merchants = Merchant.enabled
+    @disabled_merchants = Merchant.disabled
   end
 
   def show

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -11,4 +11,34 @@ class Admin::MerchantsController < ApplicationController
   def edit
     @merchant = Merchant.find(params[:id])
   end
+
+  def update
+    merchant = Merchant.find(params[:id])
+    if merchant.update(merchant_name_params)
+      redirect_to "/admin/merchants/#{merchant.id}",
+      notice: "successfully updated!"
+    else
+      redirect_to "/admin/merchants/#{merchant.id}/edit",
+      alert: "Error: #{error_message(merchant.errors)}"
+    end
+  end
+
+  def update_status
+    merchant = Merchant.find(params[:id])
+    if params[:status] == 'disable'
+      merchant.update(status: "disabled")
+      redirect_to "/admin/merchants",
+      notice: "#{merchant.name} has been disabled!"
+    elsif params[:status] == 'enable'
+      merchant.update(status: "enabled")
+      redirect_to "/admin/merchants",
+      notice: "#{merchant.name} has been enabled!"
+    end
+  end
+
+  private
+
+  def merchant_name_params
+    params.permit(:id, :name)
+  end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -2,34 +2,4 @@ class MerchantsController < ApplicationController
 
   def show
   end
-
-  def update
-    merchant = Merchant.find(params[:id])
-    if merchant.update(merchant_name_params)
-      redirect_to "/admin/merchants/#{merchant.id}",
-      notice: "successfully updated!"
-    else
-      redirect_to "/admin/merchants/#{merchant.id}/edit",
-      alert: "Error: #{error_message(merchant.errors)}"
-    end
-  end
-
-  def update_status
-    merchant = Merchant.find(params[:id])
-    if params[:status] == 'disable'
-      merchant.update(status: "disabled")
-      redirect_to "/admin/merchants",
-      notice: "#{merchant.name} has been disabled!"
-    elsif params[:status] == 'enable'
-      merchant.update(status: "enabled")
-      redirect_to "/admin/merchants",
-      notice: "#{merchant.name} has been enabled!"
-    end
-  end
-
-  private
-
-  def merchant_name_params
-    params.permit(:id, :name)
-  end
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -5,7 +5,7 @@ class MerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:id])
-    if merchant.update(merchant_params)
+    if merchant.update(merchant_name_params)
       redirect_to "/admin/merchants/#{merchant.id}",
       notice: "successfully updated!"
     else
@@ -14,9 +14,22 @@ class MerchantsController < ApplicationController
     end
   end
 
+  def update_status
+    merchant = Merchant.find(params[:id])
+    if params[:status] == 'disable'
+      merchant.update(status: "disabled")
+      redirect_to "/admin/merchants",
+      notice: "#{merchant.name} has been disabled!"
+    elsif params[:status] == 'enable'
+      merchant.update(status: "enabled")
+      redirect_to "/admin/merchants",
+      notice: "#{merchant.name} has been enabled!"
+    end
+  end
+
   private
 
-  def merchant_params
+  def merchant_name_params
     params.permit(:id, :name)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,4 @@
 class Merchant < ApplicationRecord
   has_many :items
-  has_many :dashboards
   validates :name, presence: true
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,12 @@
 class Merchant < ApplicationRecord
   has_many :items
   validates :name, presence: true
+
+  def self.enabled
+    where(status: "enabled")
+  end
+
+  def self.disabled
+    where(status: "disabled")
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: "/merchants/#{@merchant.id}", method: :patch, local: true do |f| %>
+<%= form_with url: "/admin/merchants/#{@merchant.id}", method: :patch, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name, :value => @merchant.name %>
 

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,5 +1,17 @@
-<h1> All Merchants: <br>
-  <% @merchants.each do |merchant| %>
-   <%= link_to "#{merchant.name},", {controller: "admin/merchants", action: "show", id: "#{merchant.id}"} %> <br>
+<h1> Enabled Merchants: </h1>
+<h2> <% @enabled_merchants.each do |merchant| %>
+  <div id="merchant-<%= merchant.id %>">
+    <%= link_to "#{merchant.name},", {controller: "admin/merchants", action: "show", id: "#{merchant.id}"} %>
+    <%= button_to "disable", {controller: "/merchants", action: "update_status", id: "#{merchant.id}", :status => 'disable'} %>
+  </div>
   <% end %>
-</h1>
+</h2>
+
+<h1> Disabled Merchants: </h1>
+<h2> <% @disabled_merchants.each do |merchant| %>
+  <div id="merchant-<%= merchant.id %>">
+    <%= link_to "#{merchant.name},", {controller: "admin/merchants", action: "show", id: "#{merchant.id}"} %>
+    <%= button_to "enable", {controller: "/merchants", action: "update_status", id: "#{merchant.id}", :status => 'enable'} %>
+  </div>
+  <% end %>
+</h2>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -2,7 +2,7 @@
 <h2> <% @enabled_merchants.each do |merchant| %>
   <div id="merchant-<%= merchant.id %>">
     <%= link_to "#{merchant.name},", {controller: "admin/merchants", action: "show", id: "#{merchant.id}"} %>
-    <%= button_to "disable", {controller: "/merchants", action: "update_status", id: "#{merchant.id}", :status => 'disable'} %>
+    <%= button_to "disable", {controller: "admin/merchants", action: "update_status", id: "#{merchant.id}", :status => 'disable'} %>
   </div>
   <% end %>
 </h2>
@@ -11,7 +11,7 @@
 <h2> <% @disabled_merchants.each do |merchant| %>
   <div id="merchant-<%= merchant.id %>">
     <%= link_to "#{merchant.name},", {controller: "admin/merchants", action: "show", id: "#{merchant.id}"} %>
-    <%= button_to "enable", {controller: "/merchants", action: "update_status", id: "#{merchant.id}", :status => 'enable'} %>
+    <%= button_to "enable", {controller: "admin/merchants", action: "update_status", id: "#{merchant.id}", :status => 'enable'} %>
   </div>
   <% end %>
 </h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   get "/admin", to: 'admin/dashboard#index'
 
   resources :merchants do
+    member do
+      post :update_status
+    end
     resources :invoices
     resources :items
     resources :dashboard, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,16 +4,17 @@ Rails.application.routes.draw do
   get "/admin", to: 'admin/dashboard#index'
 
   resources :merchants do
-    member do
-      post :update_status
-    end
     resources :invoices
     resources :items
     resources :dashboard, only: [:index]
   end
 
   namespace :admin do
-    resources :merchants
+    resources :merchants do
+      member do
+        post :update_status
+      end
+    end
     resources :invoices
   end
 end

--- a/db/migrate/20210414000508_create_transaction.rb
+++ b/db/migrate/20210414000508_create_transaction.rb
@@ -3,7 +3,7 @@ class CreateTransaction < ActiveRecord::Migration[5.2]
     create_table :transactions do |t|
       t.integer :credit_card_number
       t.date :credit_card_expiration_date
-      t.string :result
+      t.integer :result
       t.references :invoice, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20210415232235_add_default_status_of_enabled_to_merchant.rb
+++ b/db/migrate/20210415232235_add_default_status_of_enabled_to_merchant.rb
@@ -1,0 +1,5 @@
+class AddDefaultStatusOfEnabledToMerchant < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :string, default: "enabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema.define(version: 2021_04_15_232235) do
   create_table "transactions", force: :cascade do |t|
     t.string "credit_card_number"
     t.date "credit_card_expiration_date"
-    t.string "result"
+    t.integer "result"
     t.bigint "invoice_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_14_034828) do
+ActiveRecord::Schema.define(version: 2021_04_15_232235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_04_14_034828) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "enabled"
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/merchant_index_spec.rb
+++ b/spec/features/admin/merchant_index_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'the admin merchants index' do
     @merchant_1 = create(:merchant)
     @merchant_2 = create(:merchant)
     @merchant_3 = create(:merchant)
+    @merchant_4 = create(:merchant, status: "disabled")
   end
 
   it 'lists the names of all merchants in the system' do
@@ -22,5 +23,50 @@ RSpec.describe 'the admin merchants index' do
     expect(current_path).to eq("/admin/merchants/#{@merchant_1.id}")
 
     expect(page).to have_content(@merchant_1.name)
+  end
+
+  it 'displays enable/disable buttons' do
+    visit "/admin/merchants"
+
+    expect(page).to have_button('disable')
+    expect(page).to have_button('enable')
+  end
+
+  context "clicking first enable button" do
+    it 'redirects to index and displays enabled flash message' do
+      visit "/admin/merchants"
+
+      within "#merchant-#{@merchant_1.id}" do
+        expect(page).to have_button('disable')
+        click_button "disable"
+      end
+
+      expect(current_path).to eq("/admin/merchants")
+
+      within "#merchant-#{@merchant_1.id}" do
+        expect(page).to have_button('enable')
+      end
+
+      expect(page).to have_content("has been disabled!")
+    end
+  end
+
+  context "clicking first disable button" do
+    it 'redirects to index and displays disabled flash message' do
+      visit "/admin/merchants"
+
+      within "#merchant-#{@merchant_4.id}" do
+        expect(page).to have_button('enable')
+        click_button "enable"
+      end
+
+      expect(current_path).to eq("/admin/merchants")
+
+      within "#merchant-#{@merchant_4.id}" do
+        expect(page).to have_button('disable')
+      end
+
+      expect(page).to have_content("has been enabled!")
+    end
   end
 end


### PR DESCRIPTION
# Description

I've added enable and disable buttons on the admin_merchants index page which groups each merchants by  their current statuses. Let me know what you think!

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tested 100% with coverage
- [x] Integration tested with 100% coverage

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
