### PR TITLE
Add merchant items enable/disable buttons & group by status functionality

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,25 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(item_params[:id])
+    @merchant = Merchant.find(item_params[:merchant_id])
+  end
+
+  def edit
+    @item = Item.find(item_params[:id])
+    @merchant = Merchant.find(item_params[:merchant_id])
+  end
+
+  def update
+    merchant = Merchant.find(item_params[:merchant_id])
+    item = Item.find(item_params[:id])
+
+    if item.update(item_params)
+      redirect_to "/merchants/#{merchant.id}/items/#{item.id}",
+      notice: "successfully updated!"
+    else
+      redirect_to "/merchants/#{merchant.id}/items/#{item.id}/edit",
+      alert: "Error: #{error_message(item.errors)}"
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   def index
     @merchant = Merchant.find(item_params[:merchant_id])
+    @enabled_items = Merchant.find(item_params[:merchant_id]).items.enabled
+    @disabled_items = Merchant.find(item_params[:merchant_id]).items.disabled
   end
 
   def show
@@ -23,6 +25,20 @@ class ItemsController < ApplicationController
     else
       redirect_to "/merchants/#{merchant.id}/items/#{item.id}/edit",
       alert: "Error: #{error_message(item.errors)}"
+    end
+  end
+
+  def update_status
+    merchant = Merchant.find(item_params[:merchant_id])
+    item = Item.find(item_params[:id])
+    if params[:status] == 'disable'
+      item.update(status: "disabled")
+      redirect_to "/merchants/#{merchant.id}/items",
+      notice: "#{item.name} has been disabled!"
+    elsif params[:status] == 'enable'
+      item.update(status: "enabled")
+      redirect_to "/merchants/#{merchant.id}/items",
+      notice: "#{item.name} has been enabled!"
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,11 @@ class Item < ApplicationRecord
 
   validates :name, :description, :unit_price, :merchant_id, presence: true
 
+  def self.enabled
+    where(status: "enabled")
+  end
+
+  def self.disabled
+    where(status: "disabled")
+  end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,12 @@
+<%= form_with url: "/merchants/#{@merchant.id}/items/#{@item.id}", method: :patch, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name, :value => @item.name %>
+
+  <%= f.label :description %>
+  <%= f.text_field :description, :value => @item.description %>
+
+  <%= f.label :unit_price %>
+  <%= f.number_field :unit_price, :value => @item.unit_price %>
+
+  <%= f.submit :submit %>
+<% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,22 @@
-<h2> Items: </h2>
-  <% @merchant.items.each do |item| %>
-  <p> <%= link_to "#{item.name}", merchant_item_path(@merchant, item) %> </p>
-  <% end %>
+  <div id="enabled_items">
+    <h1> Enabled Items: </h1>
+    <h2> <% @enabled_items.each do |item| %>
+      <div id="item-<%= item.id %>">
+        <%= link_to "#{item.name}", merchant_item_path(@merchant, item) %> <%= item.status %>
+        <%= button_to "disable", {controller: "items", action: "update_status", id: "#{item.id}", :status => 'disable'} %>
+      </div>
+      <% end %>
+    </h2>
+    <br>
+  </div>
+
+  <div id="disabled_items">
+    <h1> Disabled Items: </h1>
+    <h2> <% @disabled_items.each do |item| %>
+      <div id="item-<%= item.id %>">
+        <%= link_to "#{item.name}", merchant_item_path(@merchant, item) %> <%= item.status %>
+        <%= button_to "enable", {controller: "items", action: "update_status", id: "#{item.id}", :status => 'enable'} %>
+      </div>
+      <% end %>
+    </h2>
+  </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,5 @@
-<h1> Name: <%= @item.name %> </h1>
+
+<h1> Name: <%= @item.name %> </h1> <%= link_to "Update", edit_merchant_item_path(@merchant, @item) %>
+
 <h1> Description: <%= @item.description %> </h1>
 <h1> Current Selling Price: <%= @item.unit_price %> </h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,11 @@ Rails.application.routes.draw do
   get "/admin", to: 'admin/dashboard#index'
 
   resources :merchants do
-    resources :invoices, :items
+    resources :invoices, :items do
+      member do
+        post :update_status
+      end
+    end
     resources :dashboard, only: [:index]
   end
 

--- a/db/migrate/20210420041359_add_default_status_of_disabled_to_items.rb
+++ b/db/migrate/20210420041359_add_default_status_of_disabled_to_items.rb
@@ -1,0 +1,5 @@
+class AddDefaultStatusOfDisabledToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :string, default: "disabled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_17_034845) do
+ActiveRecord::Schema.define(version: 2021_04_20_041359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2021_04_17_034845) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "disabled"
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'merchant items index' do
     @item_1 = create :item, merchant: @merchant[0]
     @item_2 = create :item, merchant: @merchant[1]
     @item_3 = create :item, merchant: @merchant[2]
+    @enabled_item = create :item, merchant: @merchant[0], status: "enabled"
   end
+
   it 'displays all items for the merchant as links to show' do
     visit "merchants/#{@merchant[0].id}/items"
 
@@ -21,5 +23,49 @@ RSpec.describe 'merchant items index' do
 
     click_link(@item_1.name)
     expect(page).to have_current_path("/merchants/#{@merchant[0].id}/items/#{@item_1.id}")
+  end
+
+  it 'displays enable/disable buttons' do
+    visit "/merchants/#{@merchant[0].id}/items"
+
+    expect(page).to have_button('disable')
+    expect(page).to have_button('enable')
+  end
+
+  context "clicking disabled item's enable button" do
+    it 'redirects to index and displays enabled flash message' do
+      visit "merchants/#{@merchant[0].id}/items"
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_button('enable')
+        click_button "enable"
+      end
+
+      expect(current_path).to eq("/merchants/#{@merchant[0].id}/items")
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_button('disable')
+      end
+      expect(page).to have_content("has been enabled!")
+    end
+  end
+
+  context "clicking enabled merchant's disable button" do
+    it 'redirects to index and displays disabled flash message' do
+      visit "/merchants/#{@merchant[0].id}/items"
+
+      within "#item-#{@enabled_item.id}" do
+        expect(page).to have_button('disable')
+        click_button "disable"
+      end
+
+      expect(current_path).to eq("/merchants/#{@merchant[0].id}/items")
+
+      within "#item-#{@enabled_item.id}" do
+        expect(page).to have_button('enable')
+      end
+
+      expect(page).to have_content("has been disabled!")
+    end
   end
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -26,9 +26,5 @@ RSpec.describe 'merchant items show' do
     click_link "Update"
 
     expect(page).to have_current_path("/merchants/#{@merchant[0].id}/items/#{@item_1.id}/edit")
-    # And I see a form filled in with the existing item attribute information
-    # When I update the information in the form and I click ‘submit’
-    # Then I am redirected back to the item show page where I see the updated information
-    # And I see a flash message stating that the information has been successfully updated.
   end
 end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'merchant items show' do
     @item_3 = create :item, merchant: @merchant[2]
   end
 
-  it "clicks an item and redirects to show" do
+  it "displays item attributes" do
     visit "/merchants/#{@merchant[0].id}/items/#{@item_1.id}"
 
     expect(page).to have_content("Name: #{@item_1.name}")
@@ -17,5 +17,18 @@ RSpec.describe 'merchant items show' do
     expect(page).to have_content("Current Selling Price: #{@item_1.unit_price}")
 
     expect(page).to_not have_content(@item_2.name)
+  end
+
+  it "clicks update link and redirects to edit page" do
+    visit "/merchants/#{@merchant[0].id}/items/#{@item_1.id}"
+
+    expect(page).to have_link("Update")
+    click_link "Update"
+
+    expect(page).to have_current_path("/merchants/#{@merchant[0].id}/items/#{@item_1.id}/edit")
+    # And I see a form filled in with the existing item attribute information
+    # When I update the information in the form and I click ‘submit’
+    # Then I am redirected back to the item show page where I see the updated information
+    # And I see a flash message stating that the information has been successfully updated.
   end
 end

--- a/spec/features/items/update_spec.rb
+++ b/spec/features/items/update_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant items edit' do
+  before(:each) do
+    @merchant = create_list(:merchant, 3)
+
+    @item_1 = create :item, merchant: @merchant[0]
+    @item_2 = create :item, merchant: @merchant[1]
+    @item_3 = create :item, merchant: @merchant[2]
+  end
+
+  it "renders edit form prefilled" do
+    visit "/merchants/#{@merchant[0].id}/items/#{@item_1.id}/edit"
+
+    expect(find('form')).to have_content('Name')
+    expect(find('form')).to have_content('Description')
+    expect(find('form')).to have_content('Unit price')
+
+    expect(page).to have_field('Name', with: "#{@item_1.name}")
+    expect(page).to have_field('Description', with: "#{@item_1.description}")
+    expect(page).to have_field('Unit price', with: "#{@item_1.unit_price}")
+  end
+
+  context "given valid data" do
+    it "submits the edit form and updates the item" do
+      visit "/merchants/#{@merchant[0].id}/items/#{@item_1.id}/edit"
+
+      fill_in('Name', with: 'Joey Haandsome')
+      click_button("submit")
+
+      expect(current_path).to eq("/merchants/#{@merchant[0].id}/items/#{@item_1.id}")
+
+      expect(page).to have_content("successfully updated!")
+      expect(page).to_not have_content("#{@item_1.name}")
+    end
+  end
+
+  context "given invalid data" do
+    it 're-renders the edit form' do
+      visit "/merchants/#{@merchant[0].id}/items/#{@item_1.id}/edit"
+
+      fill_in 'Name', with: ''
+      click_button 'submit'
+
+      expect(page).to have_content("Error: Name can't be blank")
+      expect(page).to have_current_path("/merchants/#{@merchant[0].id}/items/#{@item_1.id}/edit")
+    end
+  end
+end


### PR DESCRIPTION
# Description

I've added enable and disable buttons on the merchants_items index page which groups each item by their current statuses. Let me know what you think!

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

100% coverage on my end via:

- [x] Unit Testing
- [x] Feature Testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
